### PR TITLE
Fix dev server open

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -5,6 +5,7 @@ export default defineConfig({
   plugins: [react()],
   server: {
     port: 3000,
-    open: true
+    // Avoid auto-opening the browser in environments without a GUI
+    open: false
   }
-}) 
+})


### PR DESCRIPTION
## Summary
- disable auto open in vite config so `npm run dev` works in environments without a GUI

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68407831852c832e9fe79024eabb0d2c